### PR TITLE
Fixed crash when calling Popup.Show

### DIFF
--- a/Egui/Containers/Popup.cs
+++ b/Egui/Containers/Popup.cs
@@ -69,7 +69,7 @@ public ref partial struct Popup
     /// <summary>
     /// Is the popup open?
     /// </summary>
-    public bool IsOpen
+    public readonly bool IsOpen
     {
         get
         {
@@ -449,7 +449,8 @@ public ref partial struct Popup
     {
         var ctx = Ctx;
         using var callback = new EguiCallback(ui => addContents(new Ui(ctx, ui)));
-        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, EguiCallback, (Response?, bool)>(EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), callback);
+        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, bool, EguiCallback, (Response?, bool)>
+            (EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), IsOpen, callback);
 
         if (_openKind == OpenKind.Bool)
         {
@@ -475,7 +476,8 @@ public ref partial struct Popup
         var ctx = Ctx;
         R result = default!;
         using var callback = new EguiCallback(ui => result = addContents(new Ui(ctx, ui)));
-        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, EguiCallback, (Response?, bool)>(EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), callback);
+        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, bool, EguiCallback, (Response?, bool)>
+            (EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), IsOpen, callback);
 
         if (_openKind == OpenKind.Bool)
         {
@@ -639,7 +641,7 @@ public ref partial struct Popup
                 serializer.serialize_option_tag(false);
             }
         }
-        
+
         private static void serialize_option_SetOpenCommmand(SetOpenCommand? value, BincodeSerializer serializer)
         {
             if (value is not null)
@@ -653,9 +655,11 @@ public ref partial struct Popup
             }
         }
 
-        private static void serialize_vector_RectAlign(ImmutableArray<Egui.RectAlign> value, BincodeSerializer serializer) {
+        private static void serialize_vector_RectAlign(ImmutableArray<Egui.RectAlign> value, BincodeSerializer serializer)
+        {
             serializer.serialize_len(value.Length);
-            foreach (var item in value) {
+            foreach (var item in value)
+            {
                 item.Serialize(serializer);
             }
         }

--- a/Egui/Containers/Popup.cs
+++ b/Egui/Containers/Popup.cs
@@ -449,8 +449,7 @@ public ref partial struct Popup
     {
         var ctx = Ctx;
         using var callback = new EguiCallback(ui => addContents(new Ui(ctx, ui)));
-        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, bool, EguiCallback, (Response?, bool)>
-            (EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), IsOpen, callback);
+        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, bool, EguiCallback, (Response?, bool)>(EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), IsOpen, callback);
 
         if (_openKind == OpenKind.Bool)
         {
@@ -476,8 +475,7 @@ public ref partial struct Popup
         var ctx = Ctx;
         R result = default!;
         using var callback = new EguiCallback(ui => result = addContents(new Ui(ctx, ui)));
-        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, bool, EguiCallback, (Response?, bool)>
-            (EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), IsOpen, callback);
+        var (response, setOpen) = EguiMarshal.Call<nuint, SerializablePopup, bool, EguiCallback, (Response?, bool)>(EguiFn.egui_containers_popup_Popup_show, Ctx.Ptr, new SerializablePopup(this), IsOpen, callback);
 
         if (_openKind == OpenKind.Bool)
         {


### PR DESCRIPTION
Previously, calling Show on an instance of Popup would always lead to a crash, reporting "Failed to decode args". 

It turns out that the rust-side binding for the function expects an extra boolean:
https://github.com/DouglasDwyer/Egui.NET/blob/7d5ab46476b85d493e4fbe4b85a0a6e9ae6807d4/egui_net/src/lib.rs#L290-L293

that the C#-side does not pass:
https://github.com/DouglasDwyer/Egui.NET/blob/7d5ab46476b85d493e4fbe4b85a0a6e9ae6807d4/Egui/Containers/Popup.cs#L477-L479

So I added IsOpen as an argument to the call. I also marked IsOpen as readonly to prevent an implicit copy. Since it doesn't have a setter anyway I believe this should have no other side effects.

Calling Show on Popups now works as expected as far as I can tell.