### PR TITLE
Add CI pipeline to pack and publish NuGet package

### DIFF
--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -1,4 +1,4 @@
-name: Pack NuGet
+name: Pack
 
 on:
   push:

--- a/.github/workflows/pack-nuget.yml
+++ b/.github/workflows/pack-nuget.yml
@@ -1,0 +1,38 @@
+name: Pack NuGet
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Pack
+        run: dotnet pack Egui.NET.slnf -c Release --output nupkgs
+
+      - name: Upload nupkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkgs
+          path: nupkgs/*.nupkg

--- a/Egui.NET.slnf
+++ b/Egui.NET.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "Egui.NET.sln",
+    "projects": [
+      "Egui/Egui.csproj",
+      "Egui.Silk.NET/Egui.Silk.NET.csproj",
+      "Egui.Silk.NET.OpenGL/Egui.Silk.NET.OpenGL.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pack-nuget.yml`, which runs on every push to `main`: installs Rust (pinned toolchain), .NET 9, and `cross`, then runs `dotnet pack -c Release` and uploads the resulting `.nupkg` files as a workflow artifact.
- Adds `Egui.NET.slnf`, a solution filter scoping the pack to the three library projects (`Egui`, `Egui.Silk.NET`, `Egui.Silk.NET.OpenGL`), excluding the `SilkOpenGl` demo app (which isn't meant to be packaged and targets a different TFM).
- Release configuration builds all six `RuntimeIdentifiers` via `cross`/Docker, per the existing `Egui.csproj` build logic and the README's documented build process.

## Test plan
- [ ] Confirm the workflow runs successfully on push to `main` (requires Docker access for `cross`, available on GitHub-hosted `ubuntu-latest` runners)
- [ ] Confirm the uploaded artifact contains `Egui`, `Egui.Silk.NET`, and `Egui.Silk.NET.OpenGL` nupkgs with native libraries for all six runtime identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)