### PR TITLE
Fix nested rustdoc JSON generation being redirected by cross's CARGO_TARGET_DIR

### DIFF
--- a/egui_net_bindgen/build/main.rs
+++ b/egui_net_bindgen/build/main.rs
@@ -86,16 +86,13 @@ fn regenerate_json_docs(manifest_dir: &Path, egui_rs: &Path, out_dir: &Path) -> 
     for &crate_name in DOC_CRATES {
         let crate_manifest = egui_rs.join("crates").join(crate_name).join("Cargo.toml");
 
-        // cwd = manifest_dir so rustup resolves the toolchain from Egui.NET/rust-toolchain.toml.
-        // --target-dir is passed explicitly (rather than relying on the default,
-        // relative-to-manifest location) because tools like `cross` override
-        // CARGO_TARGET_DIR in the environment, which would otherwise redirect
-        // this nested `cargo` invocation's doc output away from egui-rs/target.
         let status = Command::new(&cargo)
+            // cwd = manifest_dir so rustup resolves the toolchain from Egui.NET/rust-toolchain.toml.
             .current_dir(manifest_dir)
             .args([
                 "rustdoc",
                 "--manifest-path", crate_manifest.to_str().expect("non-UTF8 path"),
+                // Overrides any inherited CARGO_TARGET_DIR (e.g. set by `cross`).
                 "--target-dir", egui_rs_target.to_str().expect("non-UTF8 path"),
                 "--lib",
                 "--features", "serde",

--- a/egui_net_bindgen/build/main.rs
+++ b/egui_net_bindgen/build/main.rs
@@ -81,15 +81,22 @@ fn regenerate_json_docs(manifest_dir: &Path, egui_rs: &Path, out_dir: &Path) -> 
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let mut docs = HashMap::new();
 
+    let egui_rs_target = egui_rs.join("target");
+
     for &crate_name in DOC_CRATES {
         let crate_manifest = egui_rs.join("crates").join(crate_name).join("Cargo.toml");
 
         // cwd = manifest_dir so rustup resolves the toolchain from Egui.NET/rust-toolchain.toml.
+        // --target-dir is passed explicitly (rather than relying on the default,
+        // relative-to-manifest location) because tools like `cross` override
+        // CARGO_TARGET_DIR in the environment, which would otherwise redirect
+        // this nested `cargo` invocation's doc output away from egui-rs/target.
         let status = Command::new(&cargo)
             .current_dir(manifest_dir)
             .args([
                 "rustdoc",
                 "--manifest-path", crate_manifest.to_str().expect("non-UTF8 path"),
+                "--target-dir", egui_rs_target.to_str().expect("non-UTF8 path"),
                 "--lib",
                 "--features", "serde",
                 "--",


### PR DESCRIPTION
## Summary
- After #20 fixed `cross` to actually use the custom Windows/macOS Docker images, CI started failing with a panic in `egui_net_bindgen`'s build script: `Failed to read .../egui-rs/target/doc/ecolor.json: No such file or directory`.
- Root cause: `cross` overrides `CARGO_TARGET_DIR` inside its build containers (it's on cross's list of env vars it manages itself rather than passing through, e.g. to `/target`). The build script spawns a *nested* `cargo rustdoc` invocation against the separate `egui-rs` workspace to generate rustdoc JSON, and that nested process inherited the outer, cross-set `CARGO_TARGET_DIR`, redirecting its doc output away from the `egui-rs/target/doc` path the script reads back from afterward. This was latent before #20 because `cross` was silently falling back to host `cargo`, which doesn't override `CARGO_TARGET_DIR`.
- Fix: pass `--target-dir <egui-rs>/target` explicitly on the nested invocation ([egui_net_bindgen/build/main.rs](egui_net_bindgen/build/main.rs)), so it can't be hijacked by any inherited env var.

Verified locally (with the pinned nightly toolchain) by reproducing the failure via `CARGO_TARGET_DIR=<foreign path> cargo check -p egui_net_bindgen`, then confirming the fix builds successfully under the same forced env var.

## Test plan
- [ ] Re-run the `Pack` workflow on push to `main` and confirm `egui_net_bindgen`'s build script succeeds for all six cross-compiled targets
- [ ] Confirm the resulting nupkg artifact contains native libraries for all six runtime identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)