### PR TITLE
Trigger Pack workflow on version tags, publish to GitHub Releases

### DIFF
--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -2,10 +2,10 @@ name: Pack
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   pack:
@@ -31,8 +31,7 @@ jobs:
       - name: Pack
         run: dotnet pack Egui.NET.slnf -c Release --output nupkgs
 
-      - name: Upload nupkg artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: nupkgs
-          path: nupkgs/*.nupkg
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" nupkgs/*.nupkg --generate-notes


### PR DESCRIPTION
## Summary
- Changes the `Pack` workflow's trigger from every push to `main` to pushes of `v*`-prefixed tags (e.g. `v0.7.1+0.33.2`), matching the `Version` already set in `Egui/Egui.csproj` etc.
- The `v` prefix specifically avoids collisions with the ~40 bare-version tags (`0.33.2`, `0.34.0`, ...) already in this repo from `git subtree pull`-ing the vendored `egui-rs` crate — those are upstream `emilk/egui` release tags, not Egui.NET releases, and shouldn't trigger a build.
- Instead of uploading the nupkgs as a workflow artifact, the workflow now creates a GitHub Release for the pushed tag (`gh release create`) and uploads each packed `.nupkg` as a separate release asset.
- Needs `permissions: contents: write` (up from `read`) so the built-in `GITHUB_TOKEN` can create the release and upload assets.

## Test plan
- [ ] Push a tag like `v0.7.1+0.33.2` and confirm the workflow runs and creates a GitHub Release with the `Egui`, `Egui.Silk.NET`, and `Egui.Silk.NET.OpenGL` nupkgs attached as separate assets
- [ ] Confirm pushing to `main` directly no longer triggers the workflow
- [ ] Confirm pulling in a new vendored egui-rs tag (bare version, no `v` prefix) does not trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)