### PR TITLE
Merge matching getter/setter pairs into C# properties

### DIFF
--- a/Egui/Context.cs
+++ b/Egui/Context.cs
@@ -182,7 +182,7 @@ public sealed partial class Context : EguiObject
         }
         finally
         {
-            SetGlobalStyle(style);
+            GlobalStyle = style;
         }
     }
 

--- a/egui_net_bindgen/src/lib.rs
+++ b/egui_net_bindgen/src/lib.rs
@@ -1192,8 +1192,8 @@ impl BindingsGenerator {
         }
 
         namespaces.insert("Duration".to_string(), "".to_string());
-        
-        BindingsGenerator {
+
+        let mut generator = BindingsGenerator {
             declaring_tys,
             krate,
             output_path: path.to_path_buf(),
@@ -1203,7 +1203,20 @@ impl BindingsGenerator {
             public_fields,
             parameterless_constructor_types: HashSet::new(),
             getter_setters: HashMap::new()
-        }.run()
+        };
+
+        let binding_exclude_fns = BINDING_EXCLUDE_FNS.into_iter().collect::<HashSet<_>>();
+        generator.getter_setters = generator.gather_setter_pairs(&generator.gather_fns())
+            .into_iter()
+            // A getter or setter that is individually excluded from binding must not be
+            // merged into a property, since one half of the pair would otherwise silently
+            // disappear.
+            .filter(|&(getter_id, setter_id)|
+                !binding_exclude_fns.contains(&&*generator.fn_enum_variant_name(getter_id))
+                    && !binding_exclude_fns.contains(&&*generator.fn_enum_variant_name(setter_id)))
+            .collect();
+
+        generator.run()
     }
 
     /// Executes the bindings generator.
@@ -1562,18 +1575,9 @@ impl BindingsGenerator {
 
         let mut bound_ids = Vec::new();
         let binding_exclude_fns = BINDING_EXCLUDE_FNS.into_iter().collect::<HashSet<_>>();
-
-        let fn_ids = self.gather_fns();
-        let mut getter_setters = self.gather_setter_pairs(&fn_ids);
-        // A getter or setter that is individually excluded from binding must not be merged
-        // into a property, since one half of the pair would otherwise silently disappear.
-        getter_setters.retain(|&getter_id, &mut setter_id|
-            !binding_exclude_fns.contains(&&*self.fn_enum_variant_name(getter_id))
-                && !binding_exclude_fns.contains(&&*self.fn_enum_variant_name(setter_id)));
-        self.getter_setters = getter_setters;
         let setter_ids = self.getter_setters.values().cloned().collect::<HashSet<_>>();
 
-        for id in fn_ids {
+        for id in self.gather_fns() {
             if binding_exclude_fns.contains(&&*self.fn_enum_variant_name(id)) {
                 continue;
             }
@@ -1916,14 +1920,12 @@ impl BindingsGenerator {
         Ok(())
     }
 
-    /// Finds setter functions of the form `fn set_xxx(&mut self, value: T)` that have a
-    /// corresponding getter `fn xxx(&self) -> &T` on the same type, so the two can be merged
-    /// into a single C# property with both a `get` and a `set` accessor. Functions in `ids`
-    /// that don't fit this shape (including setters without a matching getter) are left
-    /// untouched, and continue to be bound as ordinary methods.
-    ///
-    /// Returns a map from each getter's ID to its paired setter's ID.
-    fn gather_setter_pairs(&self, ids: &[RdId]) -> HashMap<RdId, RdId> {
+    /// Finds instance getter functions of the form `fn xxx(&self) -> T` or `-> &T`, keyed by
+    /// their declaring type and name, so they can be paired with a matching setter in
+    /// [`Self::gather_setter_pairs`]. Reuses [`Self::is_property`] - the same check that
+    /// decides which getters are exposed as C# properties in the first place - so only
+    /// getters that would already be bound as properties are considered as merge candidates.
+    fn gather_getters(&self, ids: &[RdId]) -> HashMap<(RdId, String), RdId> {
         let mut getters = HashMap::new();
 
         for &id in ids {
@@ -1933,11 +1935,18 @@ impl BindingsGenerator {
 
             // A getter on a primitive enum is bound as a static extension method rather than
             // an instance property, so it can never be paired with a setter accessor.
-            if !has_this || func.sig.inputs.len() != 1 || self.is_primitive_enum(decl_ty) {
+            if !has_this || self.is_primitive_enum(decl_ty) {
                 continue;
             }
 
             let ty_name = self.krate.index[&decl_ty].name.as_deref();
+            let returns_this = func.sig.output.as_ref().map(|x| x == &Type::Generic("Self".to_string()) || (if let Type::ResolvedPath(p) = x {
+                Some(p.path.as_str()) == ty_name
+            } else { false })).unwrap_or_default();
+
+            if !self.is_property(id, FnType::Instance, returns_this, func) {
+                continue;
+            }
 
             // A property can only be given a getter that returns a value outright (`T`) or an
             // immutable reference to one (`&T`) - anything else (e.g. `&mut T`) can't be
@@ -1947,12 +1956,22 @@ impl BindingsGenerator {
                 continue;
             }
 
-            if let Some(name) = self.krate.index[&id].name.as_deref()
-                && !name.contains("take") {
-                getters.insert((decl_ty, name.to_string()), id);
-            }
+            let name = self.krate.index[&id].name.as_deref().expect("Failed to get function name");
+            getters.insert((decl_ty, name.to_string()), id);
         }
 
+        getters
+    }
+
+    /// Finds setter functions of the form `fn set_xxx(&mut self, value: T)` that have a
+    /// corresponding getter `fn xxx(&self) -> &T` on the same type, so the two can be merged
+    /// into a single C# property with both a `get` and a `set` accessor. Functions in `ids`
+    /// that don't fit this shape (including setters without a matching getter) are left
+    /// untouched, and continue to be bound as ordinary methods.
+    ///
+    /// Returns a map from each getter's ID to its paired setter's ID.
+    fn gather_setter_pairs(&self, ids: &[RdId]) -> HashMap<RdId, RdId> {
+        let getters = self.gather_getters(ids);
         let mut result = HashMap::new();
 
         for &id in ids {

--- a/egui_net_bindgen/src/lib.rs
+++ b/egui_net_bindgen/src/lib.rs
@@ -1159,7 +1159,10 @@ pub struct BindingsGenerator {
     /// A list of public fields on every struct type.
     public_fields: HashSet<(String, String)>,
     /// A set containing all types for which a parameterless constructor was generated.
-    parameterless_constructor_types: HashSet<RdId>
+    parameterless_constructor_types: HashSet<RdId>,
+    /// Maps the ID of a getter function to the ID of its paired setter function, for getters
+    /// and setters that should be merged into a single C# property.
+    getter_setters: HashMap<RdId, RdId>
 }
 
 impl BindingsGenerator {
@@ -1198,7 +1201,8 @@ impl BindingsGenerator {
             namespaces,
             name_to_id,
             public_fields,
-            parameterless_constructor_types: HashSet::new()
+            parameterless_constructor_types: HashSet::new(),
+            getter_setters: HashMap::new()
         }.run()
     }
 
@@ -1559,15 +1563,35 @@ impl BindingsGenerator {
         let mut bound_ids = Vec::new();
         let binding_exclude_fns = BINDING_EXCLUDE_FNS.into_iter().collect::<HashSet<_>>();
 
-        for id in self.gather_fns() {
+        let fn_ids = self.gather_fns();
+        let mut getter_setters = self.gather_setter_pairs(&fn_ids);
+        // A getter or setter that is individually excluded from binding must not be merged
+        // into a property, since one half of the pair would otherwise silently disappear.
+        getter_setters.retain(|&getter_id, &mut setter_id|
+            !binding_exclude_fns.contains(&&*self.fn_enum_variant_name(getter_id))
+                && !binding_exclude_fns.contains(&&*self.fn_enum_variant_name(setter_id)));
+        self.getter_setters = getter_setters;
+        let setter_ids = self.getter_setters.values().cloned().collect::<HashSet<_>>();
+
+        for id in fn_ids {
             if binding_exclude_fns.contains(&&*self.fn_enum_variant_name(id)) {
                 continue;
             }
 
+            // Setters that have been paired with a getter are emitted as part of that
+            // getter's property (see `emit_cs_fn_def`), not as standalone functions.
+            if setter_ids.contains(&id) {
+                continue;
+            }
+
             let result = self.emit_cs_fn_binding(&mut std::fmt::Formatter::new(&mut result, Default::default()), id);
-            
+
             if result.is_ok() {
                 bound_ids.push(id);
+
+                if let Some(&setter_id) = self.getter_setters.get(&id) {
+                    bound_ids.push(setter_id);
+                }
             }
         }
 
@@ -1800,15 +1824,17 @@ impl BindingsGenerator {
     ) -> std::fmt::Result {
         let sig = &func.sig;
         let property = self.is_property(id, fn_ty, returns_this, func);
-        
+
         if sig.output.as_ref()
             .and_then(|x| Some(!matches!(self.bound_ty(ty_name, x)?.kind, BoundTypeKind::Value | BoundTypeKind::Reference { mutable: false })))
             .unwrap_or_default() {
             return Err(std::fmt::Error);
         }
 
+        let synchronized = ty_name.map(|name| HANDLE_TYPES.contains(&name) && name != "Context").unwrap_or_default();
+
         if property {
-            if let Some(name) = ty_name && HANDLE_TYPES.contains(&name) && name != "Context" {
+            if synchronized {
                 writeln!(f, "{{ [MethodImpl(MethodImplOptions.Synchronized)]\n get {{")?;
             }
             else {
@@ -1818,6 +1844,43 @@ impl BindingsGenerator {
         else {
             writeln!(f, "({}) {{", self.cs_binding_signature(ty_name, fn_ty, func).ok_or(std::fmt::Error)?)?;
         }
+
+        self.emit_cs_fn_body(f, ty_name, id, fn_ty, func)?;
+
+        if property {
+            writeln!(f, "}}")?;
+
+            if let Some(&setter_id) = self.getter_setters.get(&id) {
+                let ItemEnum::Function(setter_func) = &self.krate.index[&setter_id].inner else { panic!("Expected id to refer to a function") };
+
+                // Use the C# convention of naming the setter's incoming value `value`,
+                // regardless of what the parameter is called on the Rust side.
+                let mut setter_func = setter_func.clone();
+                if let Some((name, _)) = setter_func.sig.inputs.get_mut(1) {
+                    *name = "value".to_string();
+                }
+
+                if synchronized {
+                    writeln!(f, "[MethodImpl(MethodImplOptions.Synchronized)]\n set {{")?;
+                }
+                else {
+                    writeln!(f, "set {{")?;
+                }
+
+                self.emit_cs_fn_body(f, ty_name, setter_id, FnType::Instance, &setter_func)?;
+
+                writeln!(f, "}}")?;
+            }
+        }
+
+        writeln!(f, "}}")?;
+        Ok(())
+    }
+
+    /// Emits the call to the native `egui` function that backs a C# function or property
+    /// accessor, including argument marshalling and the return statement (if any).
+    fn emit_cs_fn_body(&self, f: &mut std::fmt::Formatter, ty_name: Option<&str>, id: RdId, fn_ty: FnType, func: &Function) -> std::fmt::Result {
+        let sig = &func.sig;
 
         let pointer_checks = self.cs_binding_ptr_checks(ty_name, fn_ty, func);
         writeln!(f, "    {pointer_checks}")?;
@@ -1850,12 +1913,75 @@ impl BindingsGenerator {
             writeln!(f, "    return result;")?;
         }
 
-        if property {
-            writeln!(f, "}}")?;
+        Ok(())
+    }
+
+    /// Finds setter functions of the form `fn set_xxx(&mut self, value: T)` that have a
+    /// corresponding getter `fn xxx(&self) -> &T` on the same type, so the two can be merged
+    /// into a single C# property with both a `get` and a `set` accessor. Functions in `ids`
+    /// that don't fit this shape (including setters without a matching getter) are left
+    /// untouched, and continue to be bound as ordinary methods.
+    ///
+    /// Returns a map from each getter's ID to its paired setter's ID.
+    fn gather_setter_pairs(&self, ids: &[RdId]) -> HashMap<RdId, RdId> {
+        let mut getters = HashMap::new();
+
+        for &id in ids {
+            let ItemEnum::Function(func) = &self.krate.index[&id].inner else { continue };
+            let Some(decl_ty) = self.declaring_type(id) else { continue };
+            let has_this = func.sig.inputs.first().map(|(name, _)| name == "self").unwrap_or_default();
+
+            // A getter on a primitive enum is bound as a static extension method rather than
+            // an instance property, so it can never be paired with a setter accessor.
+            if !has_this || func.sig.inputs.len() != 1 || self.is_primitive_enum(decl_ty) {
+                continue;
+            }
+
+            let ty_name = self.krate.index[&decl_ty].name.as_deref();
+
+            // A property can only be given a getter that returns a value outright (`T`) or an
+            // immutable reference to one (`&T`) - anything else (e.g. `&mut T`) can't be
+            // expressed as a plain C# property type.
+            let Some(output_bound) = func.sig.output.as_ref().and_then(|x| self.bound_ty(ty_name, x)) else { continue };
+            if !matches!(output_bound.kind, BoundTypeKind::Value | BoundTypeKind::Reference { mutable: false }) {
+                continue;
+            }
+
+            if let Some(name) = self.krate.index[&id].name.as_deref()
+                && !name.contains("take") {
+                getters.insert((decl_ty, name.to_string()), id);
+            }
         }
 
-        writeln!(f, "}}")?;
-        Ok(())
+        let mut result = HashMap::new();
+
+        for &id in ids {
+            let ItemEnum::Function(func) = &self.krate.index[&id].inner else { continue };
+            let Some(decl_ty) = self.declaring_type(id) else { continue };
+            let Some(name) = self.krate.index[&id].name.as_deref() else { continue };
+            let Some(base_name) = name.strip_prefix("set_") else { continue };
+            let has_this = func.sig.inputs.first().map(|(name, _)| name == "self").unwrap_or_default();
+
+            if !has_this || func.sig.inputs.len() != 2 {
+                continue;
+            }
+
+            let Some(&getter_id) = getters.get(&(decl_ty, base_name.to_string())) else { continue };
+            let ItemEnum::Function(getter_func) = &self.krate.index[&getter_id].inner else { continue };
+            let ty_name = self.krate.index[&decl_ty].name.as_deref();
+
+            let Some(getter_bound) = getter_func.sig.output.as_ref().and_then(|x| self.bound_ty(ty_name, x)) else { continue };
+            let Some((_, value_ty)) = func.sig.inputs.get(1) else { continue };
+            let Some(setter_bound) = self.bound_ty(ty_name, value_ty) else { continue };
+
+            // The setter's value must resolve to the same C# type as the getter's returned
+            // reference, so the property can be given a single, consistent C# type.
+            if getter_bound.name.cs_name == setter_bound.name.cs_name {
+                result.insert(getter_id, id);
+            }
+        }
+
+        result
     }
 
     /// Emits a registry of all functions that have been bound.

--- a/egui_net_bindgen/src/lib.rs
+++ b/egui_net_bindgen/src/lib.rs
@@ -1193,7 +1193,7 @@ impl BindingsGenerator {
 
         namespaces.insert("Duration".to_string(), "".to_string());
 
-        let mut generator = BindingsGenerator {
+        BindingsGenerator {
             declaring_tys,
             krate,
             output_path: path.to_path_buf(),
@@ -1203,20 +1203,7 @@ impl BindingsGenerator {
             public_fields,
             parameterless_constructor_types: HashSet::new(),
             getter_setters: HashMap::new()
-        };
-
-        let binding_exclude_fns = BINDING_EXCLUDE_FNS.into_iter().collect::<HashSet<_>>();
-        generator.getter_setters = generator.gather_setter_pairs(&generator.gather_fns())
-            .into_iter()
-            // A getter or setter that is individually excluded from binding must not be
-            // merged into a property, since one half of the pair would otherwise silently
-            // disappear.
-            .filter(|&(getter_id, setter_id)|
-                !binding_exclude_fns.contains(&&*generator.fn_enum_variant_name(getter_id))
-                    && !binding_exclude_fns.contains(&&*generator.fn_enum_variant_name(setter_id)))
-            .collect();
-
-        generator.run()
+        }.run()
     }
 
     /// Executes the bindings generator.
@@ -1233,6 +1220,7 @@ impl BindingsGenerator {
             .with_namespaces(self.namespaces.clone());
         let generator = CodeGenerator::new(&config);
 
+        self.gather_getters_setters();
         self.inject_tuple_struct_wrappers();
         self.emit_cs_fn_bindings();
         self.rename_types();
@@ -1918,6 +1906,19 @@ impl BindingsGenerator {
         }
 
         Ok(())
+    }
+
+    /// Populates [`Self::getter_setters`] with the getter/setter pairs that should be merged
+    /// into C# properties, excluding any pair where one half is individually excluded from
+    /// binding (which would otherwise cause that half to silently disappear).
+    fn gather_getters_setters(&mut self) {
+        let binding_exclude_fns = BINDING_EXCLUDE_FNS.into_iter().collect::<HashSet<_>>();
+        self.getter_setters = self.gather_setter_pairs(&self.gather_fns())
+            .into_iter()
+            .filter(|&(getter_id, setter_id)|
+                !binding_exclude_fns.contains(&&*self.fn_enum_variant_name(getter_id))
+                    && !binding_exclude_fns.contains(&&*self.fn_enum_variant_name(setter_id)))
+            .collect();
     }
 
     /// Finds instance getter functions of the form `fn xxx(&self) -> T` or `-> &T`, keyed by


### PR DESCRIPTION
## Summary
- Recognize Rust method pairs of the form `fn xxx(&self) -> T` / `&T` and `fn set_xxx(&mut self, value: T)` on the same type, and emit them as a single C# property with `get`/`set` accessors instead of two separate methods
- Update `Context.SetGlobalStyle(style)` call site to use the new `GlobalStyle` property setter

## Test plan
- [x] `cargo build -p egui_net_bindgen` and `cargo test -p egui_net_bindgen`
- [x] `cargo build -p egui_net` (regenerates bindings) and confirmed exactly the expected getter/setter pairs (e.g. `Context.GlobalStyle`) were merged into properties, with getter-only properties left untouched
- [x] `dotnet build Egui/Egui.csproj` succeeds with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)