### PR TITLE
Fix FullOutput accesskit_update wire-incompatibility with upstream egui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "egui_net"
-version = "0.7.0+0.35.0"
+version = "0.8.0+0.35.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "egui_net_bindgen"
-version = "0.7.0+0.35.0"
+version = "0.8.0+0.35.0"
 dependencies = [
  "convert_case",
  "egui",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "egui_net_ffi"
-version = "0.7.0+0.35.0"
+version = "0.8.0+0.35.0"
 dependencies = [
  "bincode",
  "egui",

--- a/egui-rs/crates/egui/src/data/input/event.rs
+++ b/egui-rs/crates/egui/src/data/input/event.rs
@@ -172,10 +172,6 @@ pub enum Event {
     WindowFocused(bool),
 
     /// An assistive technology (e.g. screen reader) requested an action.
-    // Accessibility/accesskit support is not exposed to C# (see README); skipping this
-    // variant also avoids needing `accesskit::ActionRequest` (which embeds a `Uuid`) to
-    // round-trip through the reflection-based bincode serialization used for FFI.
-    #[cfg_attr(feature = "serde", serde(skip))]
     AccessKitActionRequest(accesskit::ActionRequest),
 
     /// The reply of a screenshot requested with [`crate::ViewportCommand::Screenshot`].

--- a/egui-rs/crates/egui/src/data/output.rs
+++ b/egui-rs/crates/egui/src/data/output.rs
@@ -151,8 +151,12 @@ pub struct PlatformOutput {
     /// NOTE: this needs to be per-viewport.
     ///
     /// Accessibility/accesskit support is not exposed to C# (see README); skipped from serde
-    /// because `accesskit::TreeUpdate` embeds a `Uuid`, which can't round-trip through the
-    /// reflection-based bincode serialization used for FFI.
+    /// because `accesskit::TreeUpdate` embeds a `Node` type whose internal property map is
+    /// keyed by a private `accesskit::PropertyId` enum. That type can't be named from outside
+    /// the crate, so its variants can never be fully enumerated by the reflection-based tracer
+    /// that drives C# codegen, making this field impossible to expose there. `egui_net_ffi`
+    /// re-serializes this field manually (see `PlatformOutput2`) to stay wire-compatible with
+    /// upstream `egui`, without needing this field to be traceable.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub accesskit_update: Option<accesskit::TreeUpdate>,
 

--- a/egui_net_bindgen/src/lib.rs
+++ b/egui_net_bindgen/src/lib.rs
@@ -2476,10 +2476,7 @@ impl BindingsGenerator {
         let samples = Samples::new();
         let mut tracer = Tracer::new(TracerConfig::default()
             .default_u64_value(1)
-            // `accesskit::Uuid` (embedded in `TreeId`, used by `Event::AccessKitActionRequest`)
-            // serializes as raw bytes rather than through a newtype/tuple/struct wrapper, so it
-            // isn't covered by the `record_samples_for_*` options below. Without a 16-byte
-            // default here the tracer feeds it zero bytes and `Uuid` parsing fails.
+            // Gives `accesskit::Uuid` (in `TreeId`) a valid 16-byte sample to parse.
             .default_borrowed_bytes_value(&[0u8; 16])
             .record_samples_for_newtype_structs(true)
             .record_samples_for_tuple_structs(true)
@@ -2497,12 +2494,7 @@ impl BindingsGenerator {
         tracer.trace_simple_type::<SidesKind>().expect("Failed to trace SidesKind");
         tracer.trace_simple_type::<TextStyle>().expect("Failed to trace SidesKind");
         tracer.trace_simple_type::<WidgetText>().expect("Failed to trace WidgetText");
-        // `Event::AccessKitActionRequest` is no longer skipped from serde (see its doc comment),
-        // so the tracer now walks into these `accesskit` types. They're not part of any
-        // `DOC_CRATES` crate, so `trace_auto_egui_types` never traces them on its own; without
-        // these explicit calls the enums below would only have their first-seen variant
-        // recorded, and `registry()` would reject the registry as incomplete. They're removed
-        // from the final registry below since accesskit support isn't exposed to C#.
+        // Needed to fully trace `Event::AccessKitActionRequest`; excluded from the final registry below.
         tracer.trace_simple_type::<egui::accesskit::Action>().expect("Failed to trace Action");
         tracer.trace_simple_type::<egui::accesskit::ActionData>().expect("Failed to trace ActionData");
         tracer.trace_simple_type::<egui::accesskit::ActionRequest>().expect("Failed to trace ActionRequest");

--- a/egui_net_bindgen/src/lib.rs
+++ b/egui_net_bindgen/src/lib.rs
@@ -87,7 +87,17 @@ const BINDING_EXCLUDE_TYPES: &[&str] = &[
     "",
     "Fonts",
     // Private types
-    "Tessellator"
+    "Tessellator",
+    // Accessibility/accesskit support is not exposed to C# (see README). These are only
+    // traced so that `Event`'s `AccessKitActionRequest` variant (removed from the registry
+    // in `trace_serde_types`) can be fully enumerated; they have no other reachable use.
+    "Action",
+    "ActionData",
+    "ActionRequest",
+    "TreeId",
+    "NodeId",
+    "ScrollHint",
+    "ScrollUnit",
 ];
 
 /// Types for which fields/serialization logic should not be generated.
@@ -2466,6 +2476,11 @@ impl BindingsGenerator {
         let samples = Samples::new();
         let mut tracer = Tracer::new(TracerConfig::default()
             .default_u64_value(1)
+            // `accesskit::Uuid` (embedded in `TreeId`, used by `Event::AccessKitActionRequest`)
+            // serializes as raw bytes rather than through a newtype/tuple/struct wrapper, so it
+            // isn't covered by the `record_samples_for_*` options below. Without a 16-byte
+            // default here the tracer feeds it zero bytes and `Uuid` parsing fails.
+            .default_borrowed_bytes_value(&[0u8; 16])
             .record_samples_for_newtype_structs(true)
             .record_samples_for_tuple_structs(true)
             .record_samples_for_structs(true));
@@ -2482,7 +2497,20 @@ impl BindingsGenerator {
         tracer.trace_simple_type::<SidesKind>().expect("Failed to trace SidesKind");
         tracer.trace_simple_type::<TextStyle>().expect("Failed to trace SidesKind");
         tracer.trace_simple_type::<WidgetText>().expect("Failed to trace WidgetText");
-        
+        // `Event::AccessKitActionRequest` is no longer skipped from serde (see its doc comment),
+        // so the tracer now walks into these `accesskit` types. They're not part of any
+        // `DOC_CRATES` crate, so `trace_auto_egui_types` never traces them on its own; without
+        // these explicit calls the enums below would only have their first-seen variant
+        // recorded, and `registry()` would reject the registry as incomplete. They're removed
+        // from the final registry below since accesskit support isn't exposed to C#.
+        tracer.trace_simple_type::<egui::accesskit::Action>().expect("Failed to trace Action");
+        tracer.trace_simple_type::<egui::accesskit::ActionData>().expect("Failed to trace ActionData");
+        tracer.trace_simple_type::<egui::accesskit::ActionRequest>().expect("Failed to trace ActionRequest");
+        tracer.trace_simple_type::<egui::accesskit::TreeId>().expect("Failed to trace TreeId");
+        tracer.trace_simple_type::<egui::accesskit::NodeId>().expect("Failed to trace NodeId");
+        tracer.trace_simple_type::<egui::accesskit::ScrollHint>().expect("Failed to trace ScrollHint");
+        tracer.trace_simple_type::<egui::accesskit::ScrollUnit>().expect("Failed to trace ScrollUnit");
+
         trace_auto_egui_types(&mut tracer);
         trace_auto_emath_types(&mut tracer);
         trace_auto_epaint_types(&mut tracer);
@@ -2492,6 +2520,7 @@ impl BindingsGenerator {
         let mut result = tracer.registry().expect("Failed to generate serde registry");
 
         let Some(ContainerFormat::Enum(variants)) = result.get_mut("Event") else { panic!("Could not get Event in registry") };
+        variants.retain(|_, variant| variant.name != "AccessKitActionRequest");
         for variant in variants.values_mut() {
             if variant.name == "Key" {
                 let VariantFormat::Struct(fields) = &mut variant.value else { panic!("Event::Key did not have correct format") };

--- a/egui_net_ffi/src/lib.rs
+++ b/egui_net_ffi/src/lib.rs
@@ -110,16 +110,8 @@ impl From<FullOutput> for FullOutput2 {
     }
 }
 
-/// Holds the serializable members of [`PlatformOutput`], including `accesskit_update`.
-///
-/// `PlatformOutput::accesskit_update` is `#[serde(skip)]` (see its doc comment) because the
-/// C# reflection-based bindgen can't trace `accesskit::TreeUpdate`'s private `PropertyId` enum.
-/// But the separate (non-C#) Rust program that this crate hands serialized [`FullOutput`]s to
-/// links the official, unpatched `egui`, whose `PlatformOutput` does *not* skip this field: with
-/// it skipped here, every field serialized after it would land at the wrong byte offset once
-/// deserialized on that side. This mirror serializes the field back in using `accesskit`'s own
-/// (working) `Serialize`/`Deserialize` impl directly, without going through the reflection
-/// tracer, restoring a byte-for-byte match with the upstream layout.
+/// Holds the serializable members of [`PlatformOutput`], including `accesskit_update`
+/// (which is `#[serde(skip)]` on [`PlatformOutput`] itself; see its doc comment).
 #[derive(Clone, Serialize, Deserialize)]
 struct PlatformOutput2 {
     /// The [`PlatformOutput::commands`] field.

--- a/egui_net_ffi/src/lib.rs
+++ b/egui_net_ffi/src/lib.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 
 use egui::*;
 use egui::epaint::*;
+use egui::output::{IMEOutput, OutputEvent};
 use serde::*;
 
 /// Allows for passing `egui` data back and forth with C#.
@@ -81,7 +82,7 @@ impl Default for EguiFfi {
 #[derive(Clone, Serialize, Deserialize)]
 struct FullOutput2 {
     /// The [`FullOutput::platform_output`] field.
-    pub platform_output: PlatformOutput,
+    pub platform_output: PlatformOutput2,
     /// The [`FullOutput::textures_delta`] field.
     pub textures_delta: TexturesDelta,
     /// The [`FullOutput::pixels_per_point`] field.
@@ -92,7 +93,7 @@ impl From<FullOutput2> for FullOutput {
     fn from(value: FullOutput2) -> Self {
         Self {
             pixels_per_point: value.pixels_per_point,
-            platform_output: value.platform_output,
+            platform_output: value.platform_output.into(),
             textures_delta: value.textures_delta,
             ..Default::default()
         }
@@ -103,8 +104,65 @@ impl From<FullOutput> for FullOutput2 {
     fn from(value: FullOutput) -> Self {
         Self {
             pixels_per_point: value.pixels_per_point,
-            platform_output: value.platform_output,
+            platform_output: value.platform_output.into(),
             textures_delta: value.textures_delta
+        }
+    }
+}
+
+/// Holds the serializable members of [`PlatformOutput`], including `accesskit_update`.
+///
+/// `PlatformOutput::accesskit_update` is `#[serde(skip)]` (see its doc comment) because the
+/// C# reflection-based bindgen can't trace `accesskit::TreeUpdate`'s private `PropertyId` enum.
+/// But the separate (non-C#) Rust program that this crate hands serialized [`FullOutput`]s to
+/// links the official, unpatched `egui`, whose `PlatformOutput` does *not* skip this field: with
+/// it skipped here, every field serialized after it would land at the wrong byte offset once
+/// deserialized on that side. This mirror serializes the field back in using `accesskit`'s own
+/// (working) `Serialize`/`Deserialize` impl directly, without going through the reflection
+/// tracer, restoring a byte-for-byte match with the upstream layout.
+#[derive(Clone, Serialize, Deserialize)]
+struct PlatformOutput2 {
+    /// The [`PlatformOutput::commands`] field.
+    pub commands: Vec<OutputCommand>,
+    /// The [`PlatformOutput::cursor_icon`] field.
+    pub cursor_icon: CursorIcon,
+    /// The [`PlatformOutput::events`] field.
+    pub events: Vec<OutputEvent>,
+    /// The [`PlatformOutput::mutable_text_under_cursor`] field.
+    pub mutable_text_under_cursor: bool,
+    /// The [`PlatformOutput::ime`] field.
+    pub ime: Option<IMEOutput>,
+    /// The [`PlatformOutput::accesskit_update`] field.
+    pub accesskit_update: Option<accesskit::TreeUpdate>,
+    /// The [`PlatformOutput::num_completed_passes`] field.
+    pub num_completed_passes: usize
+}
+
+impl From<PlatformOutput2> for PlatformOutput {
+    fn from(value: PlatformOutput2) -> Self {
+        Self {
+            commands: value.commands,
+            cursor_icon: value.cursor_icon,
+            events: value.events,
+            mutable_text_under_cursor: value.mutable_text_under_cursor,
+            ime: value.ime,
+            accesskit_update: value.accesskit_update,
+            num_completed_passes: value.num_completed_passes,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<PlatformOutput> for PlatformOutput2 {
+    fn from(value: PlatformOutput) -> Self {
+        Self {
+            commands: value.commands,
+            cursor_icon: value.cursor_icon,
+            events: value.events,
+            mutable_text_under_cursor: value.mutable_text_under_cursor,
+            ime: value.ime,
+            accesskit_update: value.accesskit_update,
+            num_completed_passes: value.num_completed_passes
         }
     }
 }


### PR DESCRIPTION
## Summary

`egui_net_ffi` hands a bincode-serialized `FullOutput` to a separate Rust program linking the unmodified `egui` crate. `PlatformOutput::accesskit_update` was `#[serde(skip)]` in our vendored egui-rs but *not* in upstream egui, so with bincode's positional (non-self-describing) format, every field serialized after it landed at the wrong byte offset once decoded on the official-egui side.

- `PlatformOutput::accesskit_update` field stays `#[serde(skip)]` in the vendored egui-rs — it can't simply be un-skipped, because `accesskit::TreeUpdate` embeds a `Node` whose internal property map is keyed by a *private* `accesskit::PropertyId` enum. The reflection-based tracer that drives our C# codegen can never fully enumerate a private type's variants, so this field can never be made traceable there.
- Instead, `egui_net_ffi` now re-serializes `PlatformOutput` through a hand-written `PlatformOutput2` mirror (same trick already used for `FullOutput2`) that includes `accesskit_update` using `accesskit`'s own working `Serialize`/`Deserialize` impl directly — bypassing the tracer entirely and restoring a byte-for-byte match with upstream `egui`'s wire layout.
- `Event::AccessKitActionRequest` *is* un-skipped directly in egui-rs, since `Action`/`ActionData`/`ActionRequest`/`TreeId`/`NodeId` are all public and fully traceable with a few extra tracer calls (added to `egui_net_bindgen`, then excluded from the C# output since accesskit isn't exposed to C#, per the README).
- Un-skipping that variant also fixes a second, independent bug it was causing: `serde(skip)` on an enum variant keeps every *other* variant's original declared wire index (verified empirically), but bincode's own derived deserializer only recognizes indices renumbered to exclude the skipped variant. This meant `Event::Screenshot` (the only variant declared after `AccessKitActionRequest`) could never round-trip through bincode even *within* our own project — not just against upstream egui.

## Verification

- `cargo check --workspace` and `cargo test -p egui --features serde --lib` pass.
- Built the full `egui_net` build script (which drives the C# codegen) and confirmed the generated `Event.cs`/`PlatformOutput.cs` are unaffected (no accesskit types leak into C#, and `Screenshot`'s wire index correctly keeps the gap left by the excluded `AccessKitActionRequest` variant).
- Wrote a throwaway two-crate test (one on our patched egui-rs, one on unmodified `egui 0.35.0` from crates.io) to serialize a `PlatformOutput2` with a real `accesskit::TreeUpdate` and an `Event::Screenshot`, and confirmed:
  - The official crate decodes our `PlatformOutput2` bytes correctly, including the full `accesskit_update` payload.
  - Reverting the `Event` change reproduces the exact self-round-trip failure this fixes (`invalid value: integer 16, expected variant index 0 <= i < 16`), confirming the fix is what matters.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p egui --features serde --lib`
- [x] Manual bincode round-trip test against unmodified `egui 0.35.0` from crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)