### PR TITLE
Block default constructors on manually-written binding structs

### DIFF
--- a/Egui/Containers/HeaderResponse.cs
+++ b/Egui/Containers/HeaderResponse.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Egui.Containers;
 
 /// <summary>
@@ -12,6 +14,9 @@ public ref struct HeaderResponse
     private Response _toggleButtonResponse;
     private InnerResponse _response;
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'HeaderResponse' does not contain a constructor that takes 0 arguments", error: true)]
+    public HeaderResponse() { throw new InvalidOperationException(); }
 
     internal HeaderResponse(CollapsingState state, Ui ui, Response toggleButtonResponse, InnerResponse response)
     {
@@ -73,6 +78,10 @@ public ref struct HeaderResponse<H>
     private Ui _ui;
     private Response _toggleButtonResponse;
     private InnerResponse<H> _response;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'HeaderResponse' does not contain a constructor that takes 0 arguments", error: true)]
+    public HeaderResponse() { throw new InvalidOperationException(); }
 
     internal HeaderResponse(CollapsingState state, Ui ui, Response toggleButtonResponse, InnerResponse<H> response)
     {

--- a/Egui/Containers/Window.cs
+++ b/Egui/Containers/Window.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Egui.Containers;
 
 /// <summary>
@@ -32,6 +34,10 @@ public ref struct Window
     private bool _fadeOut;
     private bool _autoSized;
     private WindowDrag _dragArea;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'Window' does not contain a constructor that takes 0 arguments", error: true)]
+    public Window() { throw new InvalidOperationException(); }
 
     /// <summary>
     /// The window title is used as a unique Id and must be unique, and should not change.

--- a/Egui/EguiExtras/StripBuilder.cs
+++ b/Egui/EguiExtras/StripBuilder.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Egui.EguiExtras;
 
 /// <summary>
@@ -18,6 +20,10 @@ public ref struct StripBuilder
     private Layout? _cellLayout;
     private Egui.Sense _sense;
     private List<Size> _sizes;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'StripBuilder' does not contain a constructor that takes 0 arguments", error: true)]
+    public StripBuilder() { throw new InvalidOperationException(); }
 
     public StripBuilder(Ui ui)
     {

--- a/Egui/EguiExtras/Table.cs
+++ b/Egui/EguiExtras/Table.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Egui.Containers;
 
 namespace Egui.EguiExtras;
@@ -10,6 +11,10 @@ public readonly ref struct Table
     private readonly TableBuilder _builder;
     private readonly float _headerHeight;
     private readonly Action<TableRow> _headerCallback;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'Table' does not contain a constructor that takes 0 arguments", error: true)]
+    public Table() { throw new InvalidOperationException(); }
 
     internal Table(TableBuilder builder, float headerHeight, Action<TableRow> headerCallback)
     {

--- a/Egui/EguiExtras/TableBody.cs
+++ b/Egui/EguiExtras/TableBody.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.ComponentModel;
 
 namespace Egui.EguiExtras;
 
@@ -10,6 +11,10 @@ public readonly ref struct TableBody
     internal readonly nuint Ptr;
 
     private readonly Context _ctx;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'TableBody' does not contain a constructor that takes 0 arguments", error: true)]
+    public TableBody() { throw new InvalidOperationException(); }
 
     internal TableBody(Context ctx, nuint ptr)
     {

--- a/Egui/EguiExtras/TableBuilder.cs
+++ b/Egui/EguiExtras/TableBuilder.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Egui.Containers;
 
 namespace Egui.EguiExtras;
@@ -33,6 +34,10 @@ public ref struct TableBuilder
     /// The <see cref="Ui"/> that this table is being built within.
     /// </summary>
     internal readonly Ui Ui => _ui;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'TableBuilder' does not contain a constructor that takes 0 arguments", error: true)]
+    public TableBuilder() { throw new InvalidOperationException(); }
 
     public TableBuilder(Ui ui)
     {

--- a/Egui/UiArray.cs
+++ b/Egui/UiArray.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Egui;
 
 /// <summary>
@@ -29,6 +31,10 @@ public unsafe readonly ref struct UiArray
     /// The number of items in the array.
     /// </summary>
     public int Length => _length;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'UiArray' does not contain a constructor that takes 0 arguments", error: true)]
+    public UiArray() { throw new InvalidOperationException(); }
 
     /// <summary>
     /// Creates a new UI array.

--- a/Egui/Util/IdTypeMap.cs
+++ b/Egui/Util/IdTypeMap.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Egui.Util;
 
 /// <summary>
@@ -21,6 +23,10 @@ public ref struct IdTypeMap
     /// The number of values stored in this map.
     /// </summary>
     public int Length => _inner.Count;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'IdTypeMap' does not contain a constructor that takes 0 arguments", error: true)]
+    public IdTypeMap() { throw new InvalidOperationException(); }
 
     /// <summary>
     /// Creates a new map wrapper.

--- a/Egui/Widgets/Checkbox.cs
+++ b/Egui/Widgets/Checkbox.cs
@@ -1,8 +1,10 @@
+using System.ComponentModel;
+
 namespace Egui.Widgets;
 
 /// <summary>
 /// Boolean on/off control with text label.<br/>
-/// Usually you'd use <see cref="Ui.Checkbox"/> instead. 
+/// Usually you'd use <see cref="Ui.Checkbox"/> instead.
 /// </summary>
 public ref struct Checkbox : IWidget
 {
@@ -10,6 +12,10 @@ public ref struct Checkbox : IWidget
     private ref bool _checked;
     private bool _indeterminate;
     private Classes _classes;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'Checkbox' does not contain a constructor that takes 0 arguments", error: true)]
+    public Checkbox() { throw new InvalidOperationException(); }
 
     public Checkbox(ref bool isChecked, Atoms atoms)
     {

--- a/Egui/Widgets/DatePicker.cs
+++ b/Egui/Widgets/DatePicker.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Egui.Widgets;
 
 /// <summary>
@@ -7,6 +9,10 @@ public ref struct DatePicker : IWidget
 {
     private ref DateOnly _date;
     private DatePickerInner _inner;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'DatePicker' does not contain a constructor that takes 0 arguments", error: true)]
+    public DatePicker() { throw new InvalidOperationException(); }
 
     public DatePicker(ref DateOnly date)
     {

--- a/Egui/Widgets/DragValue.cs
+++ b/Egui/Widgets/DragValue.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Numerics;
 
 namespace Egui.Widgets;
@@ -9,6 +10,10 @@ public ref struct DragValue<T> : IWidget where T : INumber<T>
 {
     private ref T _value;
     private DragValueInner _inner;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'DragValue' does not contain a constructor that takes 0 arguments", error: true)]
+    public DragValue() { throw new InvalidOperationException(); }
 
     public DragValue(ref T value)
     {

--- a/Egui/Widgets/Slider.cs
+++ b/Egui/Widgets/Slider.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Numerics;
 
 namespace Egui.Widgets;
@@ -18,6 +19,10 @@ public ref struct Slider<T> : IWidget where T : INumber<T>
 {
     private ref T _value;
     private SerializableSlider _inner;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("'Slider' does not contain a constructor that takes 0 arguments", error: true)]
+    public Slider() { throw new InvalidOperationException(); }
 
     /// <summary>
     /// Creates a new horizontal slider.


### PR DESCRIPTION
## Summary
- Went through every manually-written (non-`partial`) struct binding under `Egui/` and identified the ones that lack an explicit parameterless constructor: `Window`, `Checkbox`, `TableBuilder`, `StripBuilder`, `DragValue<T>`, `Slider<T>`, `DatePicker`, `Table`, `TableBody`, `HeaderResponse`/`HeaderResponse<H>`, `IdTypeMap`, and `UiArray`.
- Because C# always synthesizes an implicit public parameterless constructor for a `struct` even when other constructors are declared, `new Window()` (etc.) previously compiled fine and produced a broken, half-initialized instance.
- Added an explicit `[EditorBrowsable(EditorBrowsableState.Never)] [Obsolete("'{Name}' does not contain a constructor that takes 0 arguments", error: true)]` constructor to each, matching exactly the pattern `egui_net_bindgen` already emits for auto-bound types (`emit_cs_deleted_constructor` in `egui_net_bindgen/src/lib.rs`), so misuse is now a compile error.
- Left plain data/output structs (`InnerResponse`, `ModifierNames`, `CollapsingResponse`, `ScrollAreaOutput`, `ModalResponse`, etc.) untouched — they're constructed internally via `new Foo { ... }` object initializers, so blocking their default constructor would break the library's own code.

## Test plan
- [ ] No local build was possible in this sandbox (no `cargo`/`dotnet` toolchain available), so this hasn't been compiled. Please run a normal build/test pass before merging.
- [x] Manually verified no call site in the repo (library or examples) constructs any of the affected types via the parameterless form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)