### PR TITLE
Fix build break from combined accesskit + record-struct PRs

### DIFF
--- a/egui_net_bindgen/src/lib.rs
+++ b/egui_net_bindgen/src/lib.rs
@@ -100,8 +100,6 @@ const BINDING_EXCLUDE_TYPES: &[&str] = &[
     "ScrollUnit",
     "Point",
     "TextPosition",
-    // Collides with the namespace used for egui's own (bound) `text_selection` module types
-    // (see `NAMESPACE_RENAMES`) if left in the registry.
     "TextSelection",
 ];
 

--- a/egui_net_bindgen/src/lib.rs
+++ b/egui_net_bindgen/src/lib.rs
@@ -98,6 +98,11 @@ const BINDING_EXCLUDE_TYPES: &[&str] = &[
     "NodeId",
     "ScrollHint",
     "ScrollUnit",
+    "Point",
+    "TextPosition",
+    // Collides with the namespace used for egui's own (bound) `text_selection` module types
+    // (see `NAMESPACE_RENAMES`) if left in the registry.
+    "TextSelection",
 ];
 
 /// Types for which fields/serialization logic should not be generated.


### PR DESCRIPTION
## Summary
- Merging [#27](https://github.com/DouglasDwyer/Egui.NET/pull/27) together with [#28](https://github.com/DouglasDwyer/Egui.NET/pull/28)/[#30](https://github.com/DouglasDwyer/Egui.NET/pull/30) left the C# build broken: un-skipping `Event::AccessKitActionRequest` in #27 made `accesskit::Point`, `accesskit::TextPosition`, and `accesskit::TextSelection` reachable by the reflection tracer, but they weren't added to `BINDING_EXCLUDE_TYPES` alongside the other accesskit-only types.
- `TextPosition` referenced the already-excluded `NodeId`, producing a generated field of a nonexistent type (`CS0234`).
- `TextSelection` collided with the `Egui.TextSelection` namespace used for egui's own (bound) `text_selection` module types, causing a duplicate-definition error (`CS0101`).
- Added `Point`, `TextPosition`, and `TextSelection` to `egui_net_bindgen`'s exclusion list, consistent with the existing `Action`/`ActionData`/`ActionRequest`/`TreeId`/`NodeId`/`ScrollHint`/`ScrollUnit` entries.

## Test plan
- [x] `dotnet build Egui.NET.sln` succeeds with 0 errors
- [x] `cargo check --workspace` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)