### PR TITLE
Add implicit conversion from Ui to Context

### DIFF
--- a/Egui/Ui.cs
+++ b/Egui/Ui.cs
@@ -117,6 +117,11 @@ public readonly ref partial struct Ui
         Ptr = ptr;
     }
 
+    /// <summary>
+    /// Gets the <see cref="Context"/> that owns this <see cref="Ui"/>. Equivalent to <see cref="Ctx"/>.
+    /// </summary>
+    public static implicit operator Context(Ui ui) => ui.Ctx;
+
     /// <inheritdoc cref="Context.Fonts"/>
     public void Fonts(Action<FontsView> reader) => Ctx.Fonts(reader);
 


### PR DESCRIPTION
## Summary
- Adds `public static implicit operator Context(Ui ui) => ui.Ctx;` so a `Ui` can be used anywhere a `Context` is expected without needing to write `.Ctx` explicitly.

Closes #37

## Test plan
- [x] `dotnet build Egui/Egui.csproj` succeeds